### PR TITLE
feat(http): merge request body with RequestOptionsArgs body

### DIFF
--- a/modules/@angular/http/src/http.ts
+++ b/modules/@angular/http/src/http.ts
@@ -22,6 +22,22 @@ function httpRequest(backend: ConnectionBackend, request: Request): Observable<R
   return backend.createConnection(request).response;
 }
 
+function objectAssign(out: any, objA: any, objB: any) {
+  out = out || {};
+
+  var objects = [objA, objB];
+
+  for (var i = 0; i < objects.length; i++) {
+    if (!objects[i]) continue;
+
+    for (var key in objects[i]) {
+      if (objects[i].hasOwnProperty(key)) out[key] = objects[i][key];
+    }
+  }
+
+  return out;
+};
+
 function mergeOptions(
     defaultOpts: BaseRequestOptions, providedOpts: RequestOptionsArgs, method: RequestMethod,
     url: string): RequestOptions {
@@ -142,20 +158,28 @@ export class Http {
    * Performs a request with `post` http method.
    */
   post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
+    var mergedOptions = this._defaultOptions.merge(new RequestOptions({body: body}));
+
+    if (isPresent(options)) {
+      options.body = objectAssign({}, body, isPresent(options) ? options.body : {});
+    }
+
     return httpRequest(
-        this._backend, new Request(mergeOptions(
-                           this._defaultOptions.merge(new RequestOptions({body: body})), options,
-                           RequestMethod.Post, url)));
+        this._backend, new Request(mergeOptions(mergedOptions, options, RequestMethod.Post, url)));
   }
 
   /**
    * Performs a request with `put` http method.
    */
   put(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
+    var mergedOptions = this._defaultOptions.merge(new RequestOptions({body: body}));
+
+    if (isPresent(options)) {
+      options.body = objectAssign({}, body, isPresent(options) ? options.body : {});
+    }
+
     return httpRequest(
-        this._backend, new Request(mergeOptions(
-                           this._defaultOptions.merge(new RequestOptions({body: body})), options,
-                           RequestMethod.Put, url)));
+        this._backend, new Request(mergeOptions(mergedOptions, options, RequestMethod.Put, url)));
   }
 
   /**
@@ -171,10 +195,14 @@ export class Http {
    * Performs a request with `patch` http method.
    */
   patch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
+    var mergedOptions = this._defaultOptions.merge(new RequestOptions({body: body}));
+
+    if (isPresent(options)) {
+      options.body = objectAssign({}, body, isPresent(options) ? options.body : {});
+    }
+
     return httpRequest(
-        this._backend, new Request(mergeOptions(
-                           this._defaultOptions.merge(new RequestOptions({body: body})), options,
-                           RequestMethod.Patch, url)));
+        this._backend, new Request(mergeOptions(mergedOptions, options, RequestMethod.Patch, url)));
   }
 
   /**

--- a/modules/@angular/http/test/http_spec.ts
+++ b/modules/@angular/http/test/http_spec.ts
@@ -13,7 +13,7 @@ import {expect} from '@angular/platform-browser/testing/matchers';
 import {Observable} from 'rxjs/Observable';
 import {zip} from 'rxjs/observable/zip';
 
-import {BaseRequestOptions, ConnectionBackend, Http, HttpModule, JSONPBackend, Jsonp, JsonpModule, Request, RequestMethod, RequestOptions, Response, ResponseContentType, ResponseOptions, URLSearchParams, XHRBackend} from '../index';
+import {BaseRequestOptions, ConnectionBackend, Headers, Http, HttpModule, JSONPBackend, Jsonp, JsonpModule, Request, RequestMethod, RequestOptions, Response, ResponseContentType, ResponseOptions, URLSearchParams, XHRBackend} from '../index';
 import {Json} from '../src/facade/lang';
 import {stringToArrayBuffer} from '../src/http_utils';
 import {MockBackend, MockConnection} from '../testing/mock_backend';
@@ -233,6 +233,23 @@ export function main() {
                async.done();
              });
              http.post(url, body).subscribe((res: Response) => {});
+           }));
+
+        it('should merge the request options default body with the body provided to the request',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             var body = {customParam: 'customParam', anotherCustomParam: 'anotherCustomParam'};
+             var requestOptions = new RequestOptions({
+               headers: new Headers({'Content-Type': 'application/json'}),
+               body: {defaultParam: 'defaultParam'}
+             });
+             backend.connections.subscribe((c: MockConnection) => {
+               var requestBody = JSON.parse(c.request.getBody());
+               expect(requestBody['customParam']).toBe('customParam');
+               expect(requestBody['anotherCustomParam']).toBe('anotherCustomParam');
+               expect(requestBody['defaultParam']).toBe('defaultParam');
+               async.done();
+             });
+             http.post(url, body, requestOptions).subscribe((res: Response) => {});
            }));
       });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/angular/angular/issues/11306


**What is the new behavior?**
The body object supplied to the POST, PATCH or PUT methods on the http service is now merged with any default body parameters that may have been specified in a RequestOptionsArgs object also supplied to those methods.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


Merge body parameters with RequestOptionsArgs body parameters if the RequestOptionsArgs param is supplied and has a default body.
The request body is a merged version of the two body parameters. This behavior is available in the POST, PUT and PATCH requests.

Closes #11306
Http post - body param not included in request, when passing RequestOptionsArgs.body